### PR TITLE
Adds timestamps as a default when generating new migrant models

### DIFF
--- a/lib/generators/templates/model.rb
+++ b/lib/generators/templates/model.rb
@@ -9,6 +9,8 @@ class <%= class_name %> < <%= parent_class_name.classify %>
     <%= attribute.name.to_s.ljust(max_field_length) %> :<%= attribute.type %>
 <%  end
    end -%>
+
+   timestamps
   end
 end
 


### PR DESCRIPTION
Maybe we should add a comment to mention that it can be removed if unneeded?
