### PR TITLE
Use safe_constantize when scanning models

### DIFF
--- a/lib/migrant/migration_generator.rb
+++ b/lib/migrant/migration_generator.rb
@@ -24,7 +24,7 @@ module Migrant
 
       Dir["#{model_root}**/*.rb"].each do |file|
         if (model_name = file.sub(model_root, '').match(/(.*)?\.rb$/))
-          model_name[1].camelize.constantize
+          model_name[1].camelize.safe_constantize
         end
       end
 


### PR DESCRIPTION
In my Rails3 applications, I have a /app/models/concerns/ directory that contains numerous files which extend ActiveSupport::Concern.

When running the 'rails generate migration' or 'rake db:upgrade' commands, migrant throws an exception when scanning these files.

rake aborted!
uninitialized constant Concerns::ActsAsSiteSpecific
/Users/matt/.rvm/gems/ruby-1.9.3-p374@pdm/gems/activesupport-3.2.14/lib/active_support/inflector/methods.rb:230:in `block in constantize'
/Users/matt/.rvm/gems/ruby-1.9.3-p374@pdm/gems/activesupport-3.2.14/lib/active_support/inflector/methods.rb:229:in`each'
/Users/matt/.rvm/gems/ruby-1.9.3-p374@pdm/gems/activesupport-3.2.14/lib/active_support/inflector/methods.rb:229:in `constantize'
/Users/matt/.rvm/gems/ruby-1.9.3-p374@pdm/gems/activesupport-3.2.14/lib/active_support/core_ext/string/inflections.rb:54:in`constantize'
/Users/matt/Sites/migrant/lib/migrant/migration_generator.rb:29:in `block in run'
/Users/matt/Sites/migrant/lib/migrant/migration_generator.rb:25:in`each'

This occurs because they're Modules not classes and there's nothing to constantize.

Using safe_constantize fixes this and allows migrant to generate migrations normally.
