### PR TITLE
minitest dependency for Rails 4

### DIFF
--- a/migrant.gemspec
+++ b/migrant.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.summary = %q{All the fun of ActiveRecord without writing your migrations, and with a dash of mocking.}
 
   s.add_development_dependency(%q<thoughtbot-shoulda>, [">= 0"])
-  s.add_development_dependency(%q<minitest>, ["~> 4.0"])
+  s.add_development_dependency(%q<minitest>, ["~> 4.2"])
   s.add_development_dependency(%q<ansi>, [">= 0"])
   s.add_development_dependency(%q<turn>, [">= 0"])
   s.add_development_dependency(%q<sqlite3>, [">= 0"])


### PR DESCRIPTION
Hi, I found in my recently fork, travis-ci fails on Rails 4 builds:

    Bundler could not find compatible versions for gem "minitest"

So just bump minitest dependency to `~> 4.2`, which is what ActiveSupport 4.0 depends on.