### PR TITLE
Avoid Rails 4.2 `serialized_attributes` deprecation warning

### DIFF
--- a/lib/migrant/model_extensions.rb
+++ b/lib/migrant/model_extensions.rb
@@ -34,8 +34,15 @@ module Migrant
         end
         # Set up serialized columns as required
         @schema.columns.select do |name, column|
-          if column.serialized? && !serialized_attributes.keys.include?(name.to_s)
-            serialize(name, column.serialized_class_name)
+          if column.serialized?
+            serialized = if defined?(::ActiveRecord::Type::Serialized)
+                           recognized_column = columns_hash[name.to_s]
+                           recognized_column && recognized_column.cast_type.is_a?(::ActiveRecord::Type::Serialized)
+                         else
+                           # Rails < 4.2
+                           serialized_attributes.keys.include?(name.to_s)
+                         end
+            serialize(name, column.serialized_class_name) unless serialized
           end
         end
       else


### PR DESCRIPTION
Hi, I'm upgrading a project using migrant to Rails 4.2, and it starts to emit warning message when encounter `structure` block with serialized columns:

```
    `serialized_attributes` is deprecated without replacement, and will be removed in Rails 5.0.
```

The rails PR is at https://github.com/rails/rails/pull/15704
Look other gems' solutions, while paper_trail provide an option to opt-out serialized attributes support, I guess we can use another alternative like what globalize gem did:
https://github.com/globalize/globalize/pull/402/files
