### PR TITLE
Workaround Integer detection for ruby 2.4 onward

### DIFF
--- a/lib/dsl/data_types/primitives.rb
+++ b/lib/dsl/data_types/primitives.rb
@@ -67,10 +67,13 @@ module DataType
       {:type => :integer, :limit => ((@value.size > 8)? @value.size : 8) }
     end
   end
-  
-  class Integer < Bignum
+
+  if 1.class.name == 'Integer' # since ruby 2.4 Integer is the general int type, so inherit our assumed general type (Fixnum)
+    class Integer < Fixnum; end
+  else
+    class Integer < Bignum; end
   end
-  
+
   class Float < Base
     def column_defaults
       {:type => :float}


### PR DESCRIPTION
Problem:
Ruby 2.4 unifies Fixnum and Bignum into Integer, a field definition `foo: 100` previously map to migrant's `DataType::Fixnum` (by asking `100.class.name`) will incorrectly change to `Integer < Bignum`.

This will cause many differences detected, and produce migration files to add `limit => 8` and might remove `default => nil` to integer fields.